### PR TITLE
Simplify steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 This is a script by which you can install Ubuntu in your termux application without rooted phone
 
-# FULLY UPDATED TO UBUNTU 19.04 DISCO
+**FULLY UPDATED TO UBUNTU 19.04 DISCO**
 
-Steps
+## Steps
 1. Update termux: `apt update && apt upgrade -y`
-2. Install wget, curl, git and proot: `apt install wget curl proot git -y`
+2. Install wget, curl and proot: `apt install wget curl proot git -y`
 3. Go to HOME folder: `cd ~`
-4. Download script: `git clone https://github.com/MFDGaming/ubuntu-in-termux.git`
-5. Go to script folder: cd ubuntu-in-termux`
-6. Give execution permission: chmod +x ubuntu.sh
-7. Run script: ./ubuntu.sh
-8. Fix resolv.conf: cp ~/ubuntu-in-termux/resolv.conf ~/ubuntu-in-termux/ubuntu-fs/etc/
-9. Now just start ubuntu: ./start.sh
+4. Download script: `curl -o ~/ubuntu.sh https://raw.githubusercontent.com/MFDGaming/ubuntu-in-termux/master/ubuntu.sh`
+5. Now just start ubuntu: ./start.sh

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # ubuntu-in-termux
+
 This is a script by which you can install Ubuntu in your termux application without rooted phone
 
 # FULLY UPDATED TO UBUNTU 19.04 DISCO
 
 Steps
-1. Update termux: apt-get update && apt-get upgrade -y
-2. Install wget: apt-get install wget -y
-3. Install proot: apt-get install proot -y
-4. Install git: apt-get install git -y
-5. Go to HOME folder: cd ~
-6. Download script: git clone https://github.com/MFDGaming/ubuntu-in-termux.git
-7. Go to script folder: cd ubuntu-in-termux
-8. Give execution permission: chmod +x ubuntu.sh
-9. Run script: ./ubuntu.sh
-10. Fix resolv.conf: cp ~/ubuntu-in-termux/resolv.conf ~/ubuntu-in-termux/ubuntu-fs/etc/
-11. Now just start ubuntu: ./start.sh
+1. Update termux: `apt update && apt upgrade -y`
+2. Install wget, curl, git and proot: `apt install wget curl proot git -y`
+3. Go to HOME folder: `cd ~`
+4. Download script: `git clone https://github.com/MFDGaming/ubuntu-in-termux.git`
+5. Go to script folder: cd ubuntu-in-termux`
+6. Give execution permission: chmod +x ubuntu.sh
+7. Run script: ./ubuntu.sh
+8. Fix resolv.conf: cp ~/ubuntu-in-termux/resolv.conf ~/ubuntu-in-termux/ubuntu-fs/etc/
+9. Now just start ubuntu: ./start.sh

--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ This is a script by which you can install Ubuntu in your termux application with
 2. Install wget, curl and proot: `apt install wget curl proot git -y`
 3. Go to HOME folder: `cd ~`
 4. Download script: `curl -o ~/ubuntu.sh https://raw.githubusercontent.com/MFDGaming/ubuntu-in-termux/master/ubuntu.sh`
-5. Now just start ubuntu: ./start.sh
+5. Change permission to executable: `chmod +x ubuntu.sh`
+6. Run Ubuntu install script: `./ubuntu.sh`
+7. Now just start ubuntu: ./start.sh


### PR DESCRIPTION
Instead of cloning a git repo we can just download the script using curl and skip `resolv.conf` because it is not needed anymore.