### PR TITLE
fix Fatal Kernel too old problem in older android

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -69,6 +69,8 @@ cd \$(dirname \$0)
 ## unset LD_PRELOAD in case termux-exec is installed
 unset LD_PRELOAD
 command="proot"
+## uncomment following line if you are having FATAL: kernel too old message.
+#command+=" -k 4.14.81"
 command+=" --link2symlink"
 command+=" -0"
 command+=" -r $directory"


### PR DESCRIPTION
To fix Fatal Kernel too old problem in older android devices. I think you should add this information to readme file too...