### PR TITLE
Change the ubuntu version because the main url has changed to 20.04.1

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -5,7 +5,7 @@ time1="$( date +"%r" )"
 
 install1 () {
 directory=ubuntu-fs
-UBUNTU_VERSION=20.04
+UBUNTU_VERSION=20.04.1
 if [ -d "$directory" ];then
 first=1
 printf "\x1b[38;5;214m[${time1}]\e[0m \x1b[38;5;227m[WARNING]:\e[0m \x1b[38;5;87m Skipping the download and the extraction\n"


### PR DESCRIPTION
The current Ubuntu base URL has changed. This difference is creating some problems when the installation is made automatically. I am just changing the new version to avoid the current errors described in:
https://github.com/MFDGaming/ubuntu-in-termux/issues/52
https://github.com/MFDGaming/ubuntu-in-termux/issues/53